### PR TITLE
Pass pickup_date to get_rates so delivery dates are relative

### DIFF
--- a/lib/active_shipping/carriers/fedex.rb
+++ b/lib/active_shipping/carriers/fedex.rb
@@ -143,7 +143,7 @@ module ActiveShipping
     end
 
     def find_rates(origin, destination, packages, options = {})
-      options = @options.update(options)
+      options = @options.merge(options)
       packages = Array(packages)
 
       rate_request = build_rate_request(origin, destination, packages, options)
@@ -154,7 +154,7 @@ module ActiveShipping
     end
 
     def find_tracking_info(tracking_number, options = {})
-      options = @options.update(options)
+      options = @options.merge(options)
 
       tracking_request = build_tracking_request(tracking_number, options)
       xml = commit(save_request(tracking_request), (options[:test] || false))
@@ -167,7 +167,7 @@ module ActiveShipping
     #  - Only supports singlular packages
     #
     def create_shipment(origin, destination, packages, options = {})
-      options = @options.update(options)
+      options = @options.merge(options)
       packages = Array(packages)
 
       begin
@@ -301,7 +301,11 @@ module ActiveShipping
           xml.VariableOptions('SATURDAY_DELIVERY')
 
           xml.RequestedShipment do
-            xml.ShipTimestamp(ship_timestamp(options[:turn_around_time]).iso8601(0))
+            if options[:pickup_date]
+              xml.ShipTimestamp(options[:pickup_date].to_time.iso8601(0))
+            else
+              xml.ShipTimestamp(ship_timestamp(options[:turn_around_time]).iso8601(0))
+            end
 
             freight = has_freight?(options)
 
@@ -476,14 +480,14 @@ module ActiveShipping
         rate_estimates = xml.root.css('> RateReplyDetails').map do |rated_shipment|
           service_code = rated_shipment.at('ServiceType').text
           is_saturday_delivery = rated_shipment.at('AppliedOptions').try(:text) == 'SATURDAY_DELIVERY'
+          is_home_delivery = service_code == "GROUND_HOME_DELIVERY"
           service_type = is_saturday_delivery ? "#{service_code}_SATURDAY_DELIVERY" : service_code
 
-          transit_time = rated_shipment.at('TransitTime').text if service_code == "FEDEX_GROUND"
-          max_transit_time = rated_shipment.at('MaximumTransitTime').try(:text) if service_code == "FEDEX_GROUND"
+          transit_time = rated_shipment.at('TransitTime').try(:text)
+          max_transit_time = rated_shipment.at('MaximumTransitTime').try(:text)
 
           delivery_timestamp = rated_shipment.at('DeliveryTimestamp').try(:text)
-
-          delivery_range = delivery_range_from(transit_time, max_transit_time, delivery_timestamp, options)
+          delivery_range = delivery_range_from(transit_time, max_transit_time, delivery_timestamp, is_home_delivery, options)
 
           currency = rated_shipment.at('RatedShipmentDetails/ShipmentRateDetail/TotalNetCharge/Currency').text
           RateEstimate.new(origin, destination, @@name,
@@ -506,13 +510,15 @@ module ActiveShipping
       RateResponse.new(success, message, Hash.from_xml(response), :rates => rate_estimates, :xml => response, :request => last_request, :log_xml => options[:log_xml])
     end
 
-    def delivery_range_from(transit_time, max_transit_time, delivery_timestamp, options)
+    def delivery_range_from(transit_time, max_transit_time, delivery_timestamp, is_home_delivery, options)
       delivery_range = [delivery_timestamp, delivery_timestamp]
 
       # if there's no delivery timestamp but we do have a transit time, use it
       if delivery_timestamp.blank? && transit_time.present?
         transit_range  = parse_transit_times([transit_time, max_transit_time.presence || transit_time])
-        delivery_range = transit_range.map { |days| business_days_from(ship_date(options[:turn_around_time]), days) }
+        pickup_date = options[:pickup_date] || ship_date(options[:turn_around_time])
+
+        delivery_range = transit_range.map { |days| business_days_from(pickup_date, days, is_home_delivery) }
       end
 
       delivery_range
@@ -531,20 +537,30 @@ module ActiveShipping
       LabelResponse.new(success, message, response_info, {labels: labels})
     end
 
-    def business_days_from(date, days)
+    def business_days_from(date, days, is_home_delivery=false)
       future_date = date
       count       = 0
 
       while count < days
         future_date += 1.day
-        count += 1 if business_day?(future_date)
+        if is_home_delivery
+          count += 1 if home_delivery_business_day?(future_date)
+        else
+          count += 1 if business_day?(future_date)
+        end
       end
 
       future_date
     end
 
+    #Transit times for FedEx® Ground do not include Saturdays, Sundays, or holidays.
     def business_day?(date)
       (1..5).include?(date.wday)
+    end
+
+    #Transit times for FedEx® Home Delivery, do not include Sundays, Mondays, or holidays.
+    def home_delivery_business_day?(date)
+      (2..6).include?(date.wday)
     end
 
     def parse_tracking_response(response, options)

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -134,7 +134,7 @@ module ActiveShipping
     end
 
     def find_tracking_info(tracking_number, options = {})
-      options = @options.update(options)
+      options = @options.merge(options)
       access_request = build_access_request
       tracking_request = build_tracking_request(tracking_number, options)
       response = commit(:track, save_request(access_request + tracking_request), options[:test])

--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -174,7 +174,7 @@ module ActiveShipping
     SERVICE_NAME_SUBSTITUTIONS = /#{ESCAPING_AND_SYMBOLS}|#{LEADING_USPS}|#{TRAILING_ASTERISKS}/
 
     def find_tracking_info(tracking_number, options = {})
-      options = @options.update(options)
+      options = @options.merge(options)
       tracking_request = build_tracking_request(tracking_number, options)
       response = commit(:track, tracking_request, options[:test] || false)
       parse_tracking_response(response, options)

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -15,19 +15,31 @@ class FedExTest < Minitest::Test
   end
 
   def test_business_days
-    today = DateTime.civil(2013, 3, 12, 0, 0, 0, "-4")
+    today = DateTime.civil(2013, 3, 12, 0, 0, 0, "-4") #Tuesday
 
     Timecop.freeze(today) do
       assert_equal DateTime.civil(2013, 3, 13, 0, 0, 0, "-4"), @carrier.send(:business_days_from, today, 1)
       assert_equal DateTime.civil(2013, 3, 15, 0, 0, 0, "-4"), @carrier.send(:business_days_from, today, 3)
+      assert_equal DateTime.civil(2013, 3, 18, 0, 0, 0, "-4"), @carrier.send(:business_days_from, today, 4)
       assert_equal DateTime.civil(2013, 3, 19, 0, 0, 0, "-4"), @carrier.send(:business_days_from, today, 5)
+    end
+  end
+
+  def test_home_delivery_business_days
+    today = DateTime.civil(2013, 3, 12, 0, 0, 0, "-4") #Tuesday
+
+    Timecop.freeze(today) do
+      assert_equal DateTime.civil(2013, 3, 13, 0, 0, 0, "-4"), @carrier.send(:business_days_from, today, 1, true)
+      assert_equal DateTime.civil(2013, 3, 15, 0, 0, 0, "-4"), @carrier.send(:business_days_from, today, 3, true)
+      assert_equal DateTime.civil(2013, 3, 16, 0, 0, 0, "-4"), @carrier.send(:business_days_from, today, 4, true)
+      assert_equal DateTime.civil(2013, 3, 19, 0, 0, 0, "-4"), @carrier.send(:business_days_from, today, 5, true)
     end
   end
 
   def test_turn_around_time_default
     mock_response = xml_fixture('fedex/ottawa_to_beverly_hills_rate_response').gsub('<v6:DeliveryTimestamp>2011-07-29</v6:DeliveryTimestamp>', '')
 
-    today = DateTime.civil(2013, 3, 11, 0, 0, 0, "-4")
+    today = DateTime.civil(2013, 3, 11, 0, 0, 0, "-4") #Monday
 
     Timecop.freeze(today) do
       delivery_date = Date.today + 7.days # FIVE_DAYS in fixture response, plus weekend


### PR DESCRIPTION
https://trello.com/c/8PTzUETf/567-2-pull-in-estimated-arrival-date-for-fedex-shipments
- get_rates takes pickup_date to give relative dates
- when Home Delivery, use its different business day schedule
