### PR TITLE
UPS. Adds ability to void shipments.

### DIFF
--- a/test/fixtures/xml/ups/void_shipment_response.xml
+++ b/test/fixtures/xml/ups/void_shipment_response.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?><VoidShipmentResponse><Response><TransactionReference></TransactionReference><ResponseStatusCode>1</ResponseStatusCode><ResponseStatusDescription>Success</ResponseStatusDescription></Response><Status>
+<StatusType>
+<Code>1</Code>
+<Description>Success</Description>
+</StatusType>
+<StatusCode>
+<Code>1</Code>
+<Description>Success</Description>
+</StatusCode>
+</Status>
+</VoidShipmentResponse>

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -279,4 +279,20 @@ class RemoteUPSTest < Minitest::Test
     next_day_delivery_estimate = response.delivery_estimates.select {|de| de.service_name == "UPS Next Day Air"}.first
     assert_equal monday + 1.day, next_day_delivery_estimate.date
   end
+
+  def test_void_shipment
+    # this is a test tracking number from the ups docs that always returns sucess
+    response = @carrier.void_shipment('1Z12345E0390817264')
+    assert response
+  end
+
+  def test_void_beyond_time_limit
+    # this is a test tracking number from the ups docs that always returns time limit expired
+    begin
+      response = @carrier.void_shipment('1Z12345E8793628675')
+      assert false # voiding this number should raise an error
+    rescue ResponseError => e
+      assert_equal(e.message, "Void shipment failed with message: Failure: Time for voiding has expired.")
+    end
+  end
 end

--- a/test/unit/carriers/ups_test.rb
+++ b/test/unit/carriers/ups_test.rb
@@ -483,4 +483,11 @@ class UPSTest < Minitest::Test
       assert delivery_estimate.service_name, UPS::DEFAULT_SERVICES[delivery_estimate.service_code]
     end
   end
+
+  def test_void_shipment
+    mock_response = xml_fixture("ups/void_shipment_response")
+    @carrier.expects(:commit).returns(mock_response)
+    response = @carrier.void_shipment('1Z12345E0390817264')
+    assert response
+  end
 end


### PR DESCRIPTION
I've created this as a PR for Shopify/ActiveShipping as well.
We might want to switch back to using theirs soon since it gets occasional update that we want.
