### PR TITLE
Ability to create a UPS return label

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -89,6 +89,25 @@ module ActiveShipping
       "07" => "UPS Express"
     }
 
+    RETURN_SERVICE_CODES = {
+      "2"  => "UPS Print and Mail (PNM)",
+      "3"  => "UPS Return Service 1-Attempt (RS1)",
+      "5"  => "UPS Return Service 3-Attempt (RS3)",
+      "8"  => "UPS Electronic Return Label (ERL)",
+      "9"  => "UPS Print Return Label (PRL)",
+      "10" => "UPS Exchange Print Return Label",
+      "11" => "UPS Pack & Collect Service 1-Attempt Box 1",
+      "12" => "UPS Pack & Collect Service 1-Attempt Box 2",
+      "13" => "UPS Pack & Collect Service 1-Attempt Box 3",
+      "14" => "UPS Pack & Collect Service 1-Attempt Box 4",
+      "15" => "UPS Pack & Collect Service 1-Attempt Box 5",
+      "16" => "UPS Pack & Collect Service 3-Attempt Box 1",
+      "17" => "UPS Pack & Collect Service 3-Attempt Box 2",
+      "18" => "UPS Pack & Collect Service 3-Attempt Box 3",
+      "19" => "UPS Pack & Collect Service 3-Attempt Box 4",
+      "20" => "UPS Pack & Collect Service 3-Attempt Box 5",
+    }
+
     TRACKING_STATUS_CODES = HashWithIndifferentAccess.new(
       'I' => :in_transit,
       'D' => :delivered,
@@ -300,8 +319,11 @@ module ActiveShipping
     # * delivery_confirmation: Can be set to any key from SHIPMENT_DELIVERY_CONFIRMATION_CODES. Can also be set on package level via package.options
     def build_shipment_request(origin, destination, packages, options={})
       packages = Array(packages)
+      shipper = options[:shipper] || origin
       options[:international] = origin.country.name != destination.country.name
-      options[:imperial] ||= IMPERIAL_COUNTRIES.include?(origin.country_code(:alpha2))
+      options[:imperial] ||= IMPERIAL_COUNTRIES.include?(shipper.country_code(:alpha2))
+      options[:return] = options[:return_service_code].present?
+      options[:reason_for_export] ||= ("RETURN" if options[:return])
 
       if allow_package_level_reference_numbers(origin, destination)
         if options[:reference_numbers]
@@ -336,7 +358,7 @@ module ActiveShipping
             build_location_node(xml, 'ShipTo', destination, options)
             build_location_node(xml, 'ShipFrom', origin, options)
             # Required element. The company whose account is responsible for the label(s).
-            build_location_node(xml, 'Shipper', options[:shipper] || origin, options)
+            build_location_node(xml, 'Shipper', shipper, options)
 
             if options[:saturday_delivery]
               xml.ShipmentServiceOptions do
@@ -389,7 +411,9 @@ module ActiveShipping
             end
 
             if options[:international]
-              build_location_node(xml, 'SoldTo', options[:sold_to] || destination, options)
+              unless options[:return]
+                build_location_node(xml, 'SoldTo', options[:sold_to] || destination, options)
+              end
 
               if origin.country_code(:alpha2) == 'US' && ['CA', 'PR'].include?(destination.country_code(:alpha2))
                 # Required for shipments from the US to Puerto Rico or Canada
@@ -402,6 +426,12 @@ module ActiveShipping
               contents_description = packages.map {|p| p.options[:description]}.compact.join(',')
               unless contents_description.empty?
                 xml.Description(contents_description)
+              end
+            end
+
+            if options[:return]
+              xml.ReturnService do
+                xml.Code(options[:return_service_code])
               end
             end
 
@@ -603,9 +633,13 @@ module ActiveShipping
 
     def build_package_node(xml, package, options = {})
       xml.Package do
-
         # not implemented:  * Shipment/Package/PackagingType element
-        #                   * Shipment/Package/Description element
+
+        #return requires description
+        if options[:return]
+          contents_description = package.options[:description]
+          xml.Description(contents_description) if contents_description
+        end
 
         xml.PackagingType do
           xml.Code('02')

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -295,4 +295,43 @@ class RemoteUPSTest < Minitest::Test
       assert_equal(e.message, "Void shipment failed with message: Failure: Time for voiding has expired.")
     end
   end
+
+  def test_obtain_return_label
+    response = @carrier.create_shipment(
+      location_fixtures[:beverly_hills_with_name],
+      location_fixtures[:real_google_as_commercial],
+      #package descriptions are required for returns
+      package_fixtures.values_at(:books),
+      {
+        :shipper => location_fixtures[:new_york],
+        :return_service_code => '9',
+        :test => true
+      }
+    )
+
+    assert response.success?
+
+    assert_instance_of ActiveShipping::LabelResponse, response
+  end
+
+  def test_obtain_international_return_label
+    response = @carrier.create_shipment(
+      location_fixtures[:ottawa_with_name],
+      #international return requires destination to have: phone number, name
+      location_fixtures[:real_google_with_name_phone],
+      #package descriptions are required for returns
+      package_fixtures.values_at(:books),
+      {
+        #international return requires shipper to have: phone, name
+        :shipper => location_fixtures[:new_york_with_name],
+        :service_code => '07',
+        :return_service_code => '9',
+        :test => true,
+      }
+    )
+
+    assert response.success?
+
+    assert_instance_of ActiveShipping::LabelResponse, response
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -151,6 +151,15 @@ module ActiveShipping::Test
                                       :address1 => '1600 Amphitheatre Parkway',
                                       :zip => '94043',
                                       :address_type => 'commercial'),
+        :real_google_with_name_phone => Location.new(
+                                      :name => 'Sergey Brin',
+                                      :country => 'US',
+                                      :city => 'Mountain View',
+                                      :state => 'CA',
+                                      :address1 => '1600 Amphitheatre Parkway',
+                                      :zip => '94043',
+                                      :phone => '1-650-253-0000',
+                                      :address_type => 'commercial'),
         :real_google_as_residential => Location.new(
                                       :country => 'US',
                                       :city => 'Mountain View',


### PR DESCRIPTION
- Create a return label by setting the return_service_code
- list of return service codes for reference
- units used are now always based on shipper's country,
  allows international return from a different country than shipper
- don't include SoldTo when it's a return
- return requires a description at the package level
